### PR TITLE
Modify json_leaf to handle numerical & boolean data properly

### DIFF
--- a/samples/sample.cc
+++ b/samples/sample.cc
@@ -13,6 +13,8 @@ int main(int argc, char **argv) {
   JLOG_PUT("hoge.ten", 10);
   JLOG_PUT("hoge.pi", 3.14);
   JLOG_PUT("hoge.hello.helloooo", "Hello");
+  JLOG_PUT("hoge.true", true);
+  JLOG_PUT("hoge.false", false);
 
   // Add
   for (int i = 0; i < 3; ++i) {


### PR DESCRIPTION
- add json_leaf_numerical&lt;T&gt; class to handle numerical data
- json_leaf is now a template class, and json_leaf&lt;int&gt;, json_leaf&lt;double&gt;, json_leaf&lt;bool&gt; are specialized
- fix a little bug
